### PR TITLE
Nanomsg 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0 (2016-01-06)
+
+  * Bump nanomsg to 0.8-beta
+  * Add new public (protocol-bind) and (protocol-connect) functions
+  * Simplify documentation and update license for 2016
+
 ## 0.7.0 (2015-11-01)
 
   * Bump lib version

--- a/EXPLAIN.md
+++ b/EXPLAIN.md
@@ -323,4 +323,4 @@ That's pretty much all I have to explain about the Nanomsg FFI binding. I'm very
 
 This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
 
-Copyright (c) 2015 Alexander Williams, Unscramble <license@unscramble.jp>
+Copyright (c) 2015-2016 Alexander Williams, Unscramble <license@unscramble.jp>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Alexander Williams, Unscramble <license@unscramble.jp>
+Copyright (c) 2015-2016 Alexander Williams, Unscramble <license@unscramble.jp>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PIL_SYMLINK_DIR ?= .lib
 ## Edit below
 BUILD_REPO = https://github.com/nanomsg/nanomsg.git
 BUILD_DIR = $(PIL_MODULE_DIR)/nanomsg/HEAD
-BUILD_REF = 0.7-beta
+BUILD_REF = 0.8-beta
 LIB_DIR = .libs
 TARGET = libnanomsg.so
 BFLAGS = --enable-shared

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2015 Alexander Williams, Unscramble <license@unscramble.jp>
+# Copyright (c) 2015-2016 Alexander Williams, Unscramble <license@unscramble.jp>
 # MIT License
 #
 # For backwards compatibility

--- a/module.l
+++ b/module.l
@@ -1,12 +1,12 @@
 [de MODULE_INFO
   ("name"       "nanomsg")
-  ("version"    "0.7.0")
+  ("version"    "0.8.0")
   ("summary"    "Nanomsg ffi-binding for PicoLisp")
   ("source"     "https://github.com/aw/picolisp-nanomsg.git")
   ("author"     "Alexander Williams")
   ("license"    "MIT")
-  ("copyright"  "(c) 2015 Alexander Williams, Unscramble <license@unscramble.jp>")
+  ("copyright"  "(c) 2015-2016 Alexander Williams, Unscramble <license@unscramble.jp>")
   ("install"    "make")
   ("requires"
     ("picolisp-unit"   "v1.0.0"      "https://github.com/aw/picolisp-unit.git")
-    ("nanomsg"         "0.7-beta"    "https://github.com/nanomsg/nanomsg.git") ]
+    ("nanomsg"         "0.8-beta"    "https://github.com/nanomsg/nanomsg.git") ]

--- a/nanomsg.l
+++ b/nanomsg.l
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 Alexander Williams, Unscramble <license@unscramble.jp>
+# Copyright (c) 2015-2016 Alexander Williams, Unscramble <license@unscramble.jp>
 
 (symbols 'nanomsg 'pico)
 
@@ -241,3 +241,9 @@
   (let Result (nn-send Sock Msg (size Msg) (non-blocking-io Dontwait) )
     (unless (exit-with-error-maybe Dontwait Result Sock)
       Result ]
+
+(de protocol-bind (Protocol Addr Domain)
+  (make-socket Addr (pack "NN_" Protocol) "BIND" Domain) )
+
+(de protocol-connect (Protocol Addr Domain)
+  (make-socket Addr (pack "NN_" Protocol) NIL Domain) )

--- a/test/test_nanomsg.l
+++ b/test/test_nanomsg.l
@@ -140,10 +140,6 @@
   '(unit~assert-throws  'InternalError
                         '(NanomsgError . "Protocol not supported")
                         '(rep-bind "tcpz://127.0.0.1:5560")
-                        "Throw an InternalError when trying to use an invalid transport" )
-  '(unit~assert-throws  'InternalError
-                        '(NanomsgError . "Invalid protocol")
-                        '(protocol-connect "REQ" "tcp://127.0.0.1:5560")
                         "Throw an InternalError when trying to use an invalid protocol" )
 
   '(test-rep-bind)

--- a/test/test_nanomsg.l
+++ b/test/test_nanomsg.l
@@ -120,6 +120,22 @@
                         Result
                         "Successfully send/receive a message using PAIR protocol" ]
 
+[de test-protocol-bind ()
+  (let (Sockpair  (protocol-bind "REP" "tcp://127.0.0.1:5560")
+        Result    (unit~assert-equal  '(0 . 1)
+                                      Sockpair
+                                      "Protocol REP-BIND socket is created") )
+      (end-sock Sockpair)
+      Result ]
+
+[de test-protocol-connect ()
+  (let (Sockpair  (protocol-connect "REQ" "tcp://127.0.0.1:5560")
+        Result    (unit~assert-equal  '(0 . 1)
+                                      Sockpair
+                                      "Protocol REQ-CONNECT socket is created") )
+      (end-sock Sockpair)
+      Result ]
+
 [unit~execute
   '(unit~assert-throws  'InternalError
                         '(NanomsgError . "Protocol not supported")
@@ -138,4 +154,6 @@
   '(test-push-connect)
   '(test-survey-bind)
   '(test-respond-connect)
-  '(test-send-recv) ]
+  '(test-send-recv)
+  '(test-protocol-bind)
+  '(test-protocol-connect) ]

--- a/test/test_nanomsg.l
+++ b/test/test_nanomsg.l
@@ -140,6 +140,10 @@
   '(unit~assert-throws  'InternalError
                         '(NanomsgError . "Protocol not supported")
                         '(rep-bind "tcpz://127.0.0.1:5560")
+                        "Throw an InternalError when trying to use an invalid transport" )
+  '(unit~assert-throws  'InternalError
+                        '(NanomsgError . "Invalid protocol")
+                        '(protocol-connect "REQ" "tcp://127.0.0.1:5560")
                         "Throw an InternalError when trying to use an invalid protocol" )
 
   '(test-rep-bind)


### PR DESCRIPTION
Update Nanomsg to `0.8-beta` and add new public functions to simplify usage.
- `(protocol-bind)`
- `(protocol-connect)`

The old public functions are still accessible, so this addition is backwards compatible.
